### PR TITLE
fix: Explicit use of x86_64 image

### DIFF
--- a/src/aws-amplify-hosting.ts
+++ b/src/aws-amplify-hosting.ts
@@ -154,7 +154,7 @@ export class Repository extends codecommit.Repository {
       runtime: lambda.Runtime.PYTHON_3_9,
       code: lambda.Code.fromAsset('./src/functions/copy-git-repo', {
         bundling: {
-          image: lambda.Runtime.PYTHON_3_9.bundlingImage,
+          image: cdk.DockerImage.fromRegistry('public.ecr.aws/sam/build-python3.9:latest-x86_64'),
           command: [
             '/bin/bash', '-c', [
               'mkdir -p /var/task/local/{bin,lib}',

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -3593,7 +3593,7 @@ Object {
               Object {
                 "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
               },
-              "/07aee184fbce7eedfc37d5a223a0d3b757f2aefd57ed8d24c11746a630b335a1.json",
+              "/4e754b744506947730dab9f8381dfe9fb3cd8c2b3399979dd185dae1d4b699c4.json",
             ],
           ],
         },
@@ -4606,7 +4606,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "45b1f0daee9c2bf059b2c5bb6613b1b4db8c42fc790895756fa822a2b0de522d.zip",
+          "S3Key": "d0d86ac5e8de299a074aae1d2befd409ee1fd6601719bb80421ec93cf0f3a391.zip",
         },
         "Description": "Supabase - Database init function",
         "Environment": Object {
@@ -5024,7 +5024,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f5d98e0eb2c0f44d898910e4aeb89b5d55514aac10d644ce996e505112ada463.zip",
+          "S3Key": "46cb22674a0133d9783e8d76788baa1cc119e0254097f04c26d84b874617f495.zip",
         },
         "Description": "Supabase - Sync DB secret to parameter store",
         "Environment": Object {
@@ -6434,7 +6434,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "32170b7bd19a2da5f973cae347287a1ad2e9d557e6ffd44d30ba180c31931123.zip",
+          "S3Key": "db5a5dee36c17b16cf18da872381baa5dbf682aebf1601fddbef8d99e3765661.zip",
         },
         "Description": Object {
           "Fn::Join": Array [
@@ -9327,7 +9327,7 @@ Object {
               Object {
                 "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
               },
-              "/84e28f799fac6586e9ed52d4c9e952deca5c9dab4e6aeb42c2dc5426ceb8579d.json",
+              "/f1912e4deddb05f75be1bc822bf8cee1d38dc99ebcae012e9064f9f54801a507.json",
             ],
           ],
         },
@@ -10459,7 +10459,7 @@ applications:
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "ad1e3feacca3f9394acbacc9cc574dc94b1411a0c2b0ff3d65912db8935e9fab.zip",
+          "S3Key": "ff94d8cd7c37caea99d4902983e873bdf275ba78260343685c1f2b15933f7f87.zip",
         },
         "Description": "Clone to CodeCommit from remote repo (You can execute this function manually.)",
         "Environment": Object {


### PR DESCRIPTION
## Context

When I run `cdk deploy` from a laptop with Apple Silicon, cdk builds a lambda function using the arm64 image.
However, the git sync function fails because it runs on the x86_64 platform in the Cloud.

I need to build a lambda function using the x86_64 image.