### PR TITLE
Give postgres user permissions on auth

### DIFF
--- a/src/functions/db-init/01-auth-schema.sql
+++ b/src/functions/db-init/01-auth-schema.sql
@@ -143,3 +143,8 @@ ALTER FUNCTION "auth"."email" OWNER TO supabase_auth_admin;
 GRANT EXECUTE ON FUNCTION "auth"."uid"() TO PUBLIC;
 GRANT EXECUTE ON FUNCTION "auth"."role"() TO PUBLIC;
 GRANT EXECUTE ON FUNCTION "auth"."email"() TO PUBLIC;
+
+-- User `postgres` also should have access to the auth schema
+GRANT ALL PRIVILEGES ON SCHEMA auth TO postgres;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA auth TO postgres;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA auth TO postgres;


### PR DESCRIPTION
In the Supabase Cloud, the `postgres` role has access to the auth tables too. This PR grants this role the same permissions in this version of the DB.

I know that the roles are much different in general after https://github.com/orgs/supabase/discussions/9314 but I didn't migrate over to the latest role permissions from Supabase, mostly because they seem to be working on an overhaul of role management anyways and there is not enough documentation for me to do it in the time that I have. In any case, I hope that this PR at least offers a way for others who encountered permission issues.