### PR TITLE
fix: change domain name of realtime

### DIFF
--- a/src/supabase-stack.ts
+++ b/src/supabase-stack.ts
@@ -447,6 +447,7 @@ export class SupabaseStack extends FargateStack {
 
     /** Websocket API */
     const realtime = new AutoScalingFargateService(this, 'Realtime', {
+      serviceName: 'realtime-dev',
       cluster,
       taskImageOptions: {
         image: ecs.ContainerImage.fromRegistry(realtimeImageUri.valueAsString),

--- a/src/supabase-stack.ts
+++ b/src/supabase-stack.ts
@@ -447,7 +447,7 @@ export class SupabaseStack extends FargateStack {
 
     /** Websocket API */
     const realtime = new AutoScalingFargateService(this, 'Realtime', {
-      serviceName: 'realtime-dev',
+      serviceName: 'realtime-dev', // The sub-domain is used as tenat_id. (<tenat_id>.supabase.internal)
       cluster,
       taskImageOptions: {
         image: ecs.ContainerImage.fromRegistry(realtimeImageUri.valueAsString),

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -6164,7 +6164,7 @@ Object {
               },
               Object {
                 "Name": "SUPABASE_REALTIME_URL",
-                "Value": "http://realtime.supabase.internal:4000/socket/",
+                "Value": "http://realtime-dev.supabase.internal:4000/socket/",
               },
               Object {
                 "Name": "SUPABASE_STORAGE_URL",
@@ -7134,7 +7134,7 @@ Object {
         "HealthCheckCustomConfig": Object {
           "FailureThreshold": 1,
         },
-        "Name": "realtime",
+        "Name": "realtime-dev",
         "NamespaceId": Object {
           "Fn::GetAtt": Array [
             "ClusterDefaultServiceDiscoveryNamespaceC336F9B4",


### PR DESCRIPTION
Fixes #66

In the case of self-hosting, `realtime-dev` is used as tenat_id, but the subdomain is used to determine tenat_id.
The domain name must be set to something like `realtime-dev.supabase.internal`.