### PR TITLE
fix: add brackets to Kong secrets in template

### DIFF
--- a/containers/kong/kong-template.yml
+++ b/containers/kong/kong-template.yml
@@ -17,10 +17,10 @@ consumers:
   - username: DASHBOARD
   - username: anon
     keyauth_credentials:
-      - key: $SUPABASE_ANON_KEY
+      - key: ${SUPABASE_ANON_KEY}
   - username: service_role
     keyauth_credentials:
-      - key: $SUPABASE_SERVICE_KEY
+      - key: ${SUPABASE_SERVICE_KEY}
 
 ###
 ### Access Control List


### PR DESCRIPTION
This commit fixes the syntax of the Kong template secrets - an earlier commit dropped the curly brackets which caused the service to be unable to read the secrets.

Fixes #79
