### PR TITLE
chore: updated README.md to removed trailing commas, and renamed Sids to fix AWS IAM Policy Json Syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,12 +119,12 @@ This repo includes a template of starting Supabase stack on AWS via CloudFormati
                 "ssm:*",
                 "states:*",
                 "rds:*",
-                "route53:*",
+                "route53:*"
             ],
             "Resource": "*"
         },
         {
-            "Sid": "supabase-cdn",
+            "Sid": "supabaseCDN",
             "Effect": "Allow",
             "Action": [
                 "cloudfront:*",
@@ -134,18 +134,18 @@ This repo includes a template of starting Supabase stack on AWS via CloudFormati
             "Resource": "*"
         },
         {
-            "Sid": "cache-manager",
+            "Sid": "cacheManager",
             "Effect": "Allow",
             "Action": [
                 "apigateway:*",
                 "lambda:*",
                 "logs:*",
-                "sqs:*",
+                "sqs:*"
             ],
             "Resource": "*"
         },
         {
-            "Sid": "supabase-studio",
+            "Sid": "supabaseStudio",
             "Effect": "Allow",
             "Action": [
                 "amplify:*",


### PR DESCRIPTION
The current documentation's IAM policy contains a trailing coma which gets flagged when it gets copied from the documentation to AWS console. The SID is also flagged with an Error Unsupported SID; to resolved this, I renamed  the hyphened SID to camel case.
